### PR TITLE
.gitignore에 jpa buddy 플러그인의 설정 파일을 무시하도록 룰 추가

### DIFF
--- a/project-board/.gitignore
+++ b/project-board/.gitignore
@@ -4,6 +4,9 @@
 ## Querysdl
 /src/main/generated
 
+### JPA Buddy
+.jpb/
+
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/project-board/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -3,14 +3,8 @@ package com.fastcampus.projectboard.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;

--- a/project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -3,14 +3,8 @@ package com.fastcampus.projectboard.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter

--- a/project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
@@ -10,8 +10,6 @@ import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-import java.time.DateTimeException;
-
 @RepositoryRestResource
 public interface ArticleCommentRepository extends
         JpaRepository<ArticleComment, Long>,

--- a/project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
@@ -10,8 +10,6 @@ import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-import java.time.DateTimeException;
-
 @RepositoryRestResource
 public interface ArticleRepository extends
         JpaRepository<Article, Long>,

--- a/project-board/src/test/java/com/fastcampus/projectboard/repository/JpaRepositoryTest.java
+++ b/project-board/src/test/java/com/fastcampus/projectboard/repository/JpaRepositoryTest.java
@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("JPA 연결 테스트")
 @Import(JpaConfig.class)


### PR DESCRIPTION
intellij plugin 중 jpa 작업을 편하게 해주는 jpa buddy라는 플러그인으로 인해 자동 생성되는 설정 파일이 프로젝트에 포함되지 않도록 무시 규칙을 추가함